### PR TITLE
fix: correct Windows icon size in skills array

### DIFF
--- a/arraySkills.js
+++ b/arraySkills.js
@@ -226,7 +226,7 @@ export const arraySkills = [
             },
             {
                 title: "Windows (11/10/7/Server)",
-                image: ' <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/windows11/windows11-original.svg" />" height="20" width="20" />',
+                image: '<img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/windows11/windows11-original.svg" height="20" width="20" />',
                 link: ""
             }
         ]


### PR DESCRIPTION
## Summary
- fix Windows OS logo size in arraySkills

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b69c9ebf60832aae3615f1ceb21d16